### PR TITLE
CascadedDetector returning empty list instead of ndarray instance

### DIFF
--- a/py/facedet/detector.py
+++ b/py/facedet/detector.py
@@ -72,7 +72,7 @@ class CascadedDetector(Detector):
 		src = cv2.equalizeHist(src)
 		rects = self.cascade.detectMultiScale(src, scaleFactor=self.scaleFactor, minNeighbors=self.minNeighbors, minSize=self.minSize)
 		if len(rects) == 0:
-			return []
+			return np.ndarray((0,))
 		rects[:,2:] += rects[:,:2]
 		return rects
 


### PR DESCRIPTION
When a call is made to `self.cascade.detectMultiScale` in line 73 if no rects are returned, then the variable `rects` becomes an empty tuple. This case is handled incorrectly in line 75, as this function should return `numpy.ndarray` instances.