### PR TITLE
Changed LDA Feature class to handle non-continuous sets of class labels

### DIFF
--- a/py/facerec/feature.py
+++ b/py/facerec/feature.py
@@ -113,7 +113,7 @@ class LDA(AbstractFeature):
         y = np.asarray(y)
         # calculate dimensions
         d = XC.shape[0]
-        c = len(np.unique(y))        
+        c = len(np.unique(y))
         # set a valid number of components
         if self._num_components <= 0:
             self._num_components = c-1
@@ -124,7 +124,7 @@ class LDA(AbstractFeature):
         # calculate the within and between scatter matrices
         Sw = np.zeros((d, d), dtype=np.float32)
         Sb = np.zeros((d, d), dtype=np.float32)
-        for i in range(0,c):
+        for i in np.unique(y):
             Xi = XC[:,np.where(y==i)[0]]
             meanClass = np.mean(Xi, axis = 1).reshape(-1,1)
             Sw = Sw + np.dot((Xi-meanClass), (Xi-meanClass).T)


### PR DESCRIPTION
Before, class labels were assumed to be {0,1,2,3,..., n}.  Now, labels may be {1, 3, 7, ..., n}.  I found myself needing to train and test on subsets of my subjects, as in just subjects 1, 3, 7, etc., and wanted to retain their original class labeling.  Furthermore, my first class label was not 0, it was 1, as subject 1 is the first subject in the AT&T dataset.  I wanted my class labels to directly reflect the subject's number.