### PR TITLE
In Readme.md for the example script size is incorrectly referred to as self.sz, changed it to simply sz

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -216,7 +216,7 @@ def read_images(path, sz=None):
                     im = im.convert("L")
                     # resize to given size (if given)
                     if (sz is not None):
-                        im = im.resize(self.sz, Image.ANTIALIAS)
+                        im = im.resize(sz, Image.ANTIALIAS)
                     X.append(np.asarray(im, dtype=np.uint8))
                     y.append(c)
                 except IOError, (errno, strerror):


### PR DESCRIPTION
I was trying to use facerec for a personal project but was facing a few problems as my images were not of the same size so I tried using the sz parameter but the script crashed. These edits should fix it.
